### PR TITLE
Detach pre-config enviroment from the one specified by project

### DIFF
--- a/makefile/.konveyor/pre-commit/setup_env.mk
+++ b/makefile/.konveyor/pre-commit/setup_env.mk
@@ -1,0 +1,26 @@
+### Important, the LOCAL_LANG_DIR must match one from Makefile
+LOCAL_LANG_DIR=pre-commit
+
+PYTHON_BINARY=python3
+
+ifeq (, $(shell which $(PYTHON_BINARY) ))
+  $(error "PYTHON=$(PYTHON_BINARY) binary not found in $(PATH)")
+endif
+
+ifndef PYTHON_VENV
+  PYTHON_VENV=.venv
+endif
+
+$(PYTHON_VENV):
+	test -d ${PYTHON_VENV} || ${PYTHON_BINARY} -m venv ${PYTHON_VENV}
+	. ${PYTHON_VENV}/bin/activate && pip install -U pip
+	touch ${PYTHON_VENV}
+
+pre-commit-$(PYTHON_VENV): $(PYTHON_VENV)
+
+$(LOCAL_LANG_DIR)-clean-env:
+	rm -rf ${PYTHON_VENV}
+	find . -iname "*.pyc" -delete
+
+.PHONY: $(LANG_DIR)-$(PYTHON_VENV)
+$(LOCAL_LANG_DIR)-$(PYTHON_VENV): $(PYTHON_VENV)

--- a/makefile/.konveyor/python/.pre-commit-config.yaml
+++ b/makefile/.konveyor/python/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:

--- a/makefile/.konveyor/python/setup_env.mk
+++ b/makefile/.konveyor/python/setup_env.mk
@@ -1,26 +1,12 @@
 ### Important, the LANG_DIR must match one from Makefile
-LANG_DIR=python
- 
-PYTHON_BINARY=python3
+LOCAL_LANG_DIR=python
 
-ifeq (, $(shell which $(PYTHON_BINARY) ))
-  $(error "PYTHON=$(PYTHON_BINARY) binary not found in $(PATH)")
-endif
-
-ifndef PYTHON_VENV
-  PYTHON_VENV=.venv
-endif
-
-$(PYTHON_VENV):
-	test -d ${PYTHON_VENV} || ${PYTHON_BINARY} -m venv ${PYTHON_VENV}
-	. ${PYTHON_VENV}/bin/activate && pip install -U pip
-	touch ${PYTHON_VENV}
-
-$(LANG_DIR)-dev-env: $(PYTHON_VENV)
+$(LOCAL_LANG_DIR)-dev-env: $(PYTHON_VENV)
 	$(info **** To run VENV: $$source ${PYTHON_VENV}/bin/activate)
 	$(info **** To later deactivate VENV: $$deactivate)
-	$(info **** To destroy: make clean-dev-env)
+	$(info **** To destroy: make go-away)
 
-$(LANG_DIR)-clean-dev-env:
-	rm -rf ${PYTHON_VENV}
-	find . -iname "*.pyc" -delete
+# Clean-up specific to python. Note that .venv is destroyed by
+# clean-up from setup_env.mk from pre-commit.
+$(LOCAL_LANG_DIR)-clean-dev-env:
+	@echo "Cleaning up..."

--- a/makefile/Makefile
+++ b/makefile/Makefile
@@ -12,7 +12,7 @@ endif
 
 # Makefile targets which are common across all projects
 .PHONY: tests
-.PHONY: dev-env clean-dev-env
+.PHONY: dev-env go-away
 
 tests:
 	$(MAKE) $(LANG_DIR)-tests
@@ -20,14 +20,19 @@ tests:
 dev-env:
 	$(MAKE) $(LANG_DIR)-dev-env
 
-clean-dev-env:
+go-away:
 	$(MAKE) $(LANG_DIR)-clean-dev-env
+	$(MAKE) pre-commit-clean-env
 
 ### Python environment is needed to run pre-commit CLI
-include ./$(MK_SCRIPTS_DIR)/python/setup_env.mk
-setup-pre-commit: $(PYTHON_VENV)
+include ./$(MK_SCRIPTS_DIR)/pre-commit/setup_env.mk
+setup-pre-commit: pre-commit-$(PYTHON_VENV)
 	. ${PYTHON_VENV}/bin/activate && pip install pre-commit \
 	  > ${PYTHON_VENV}/pre-commit-install.log
+
+ifneq ("$(wildcard ./$(MK_SCRIPTS_DIR)/$(LANG_DIR)/setup_env.mk)","")
+    include ./$(MK_SCRIPTS_DIR)/$(LANG_DIR)/setup_env.mk
+endif
 
 ### Include lanuguage specific parts of the Makefile
 ifneq ("$(wildcard ./$(MK_SCRIPTS_DIR)/$(LANG_DIR)/tests.mk)","")


### PR DESCRIPTION
Currently pre-commit was wrapped around python directory,
which is not ideal as for the non-pythonic projects python
had to be included. This change separates the python from
pre-commit include.