### PR TITLE
fix #5 Ansible linting as a separate test call

### DIFF
--- a/makefile/.konveyor/ansible/.pre-commit-config.yaml
+++ b/makefile/.konveyor/ansible/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
   rev: v6.0.2
   hooks:
     - id: ansible-lint
-      files: \.(yaml|yml)$

--- a/makefile/.konveyor/ansible/.pre-commit-config.yaml
+++ b/makefile/.konveyor/ansible/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/ansible-community/ansible-lint.git
+  rev: v6.0.2
+  hooks:
+    - id: ansible-lint
+      files: \.(yaml|yml)$

--- a/makefile/.konveyor/ansible/tests.mk
+++ b/makefile/.konveyor/ansible/tests.mk
@@ -6,3 +6,6 @@ $(LOCAL_LANG_DIR)-tests:
 
 pre-commit: setup-pre-commit
 	. ${PYTHON_VENV}/bin/activate && pre-commit
+
+ansible-lint: setup-pre-commit
+	. ${PYTHON_VENV}/bin/activate && pre-commit run ansible-lint


### PR DESCRIPTION
Since Ansible benefits most from the linting, I added ansible linting as a separate test.
This is universaly true for any ansible project.

This PR fixes #5 