### PR TITLE
Change go installation to extract all files and include go version

### DIFF
--- a/makefile/.konveyor/go/setup_env.mk
+++ b/makefile/.konveyor/go/setup_env.mk
@@ -1,18 +1,9 @@
 ### Important, the LANG_DIR must match one from Makefile
 LANG_DIR=go
 
-GO_VENV:
-	mkdir .venv
-	mkdir .venv/bin
-
-$(LANG_DIR)-dev-env: GO_VENV
+# We require PYTHON_VENV for the pre-commit CLI
+$(LANG_DIR)-dev-env: $(PYTHON_VENV)
 	./$(COMMON_GIT_DIR)/makefile/scripts/install_dev_tools -v .venv -c go
-	export  PATH=$PATH:.venv/bin
-	export GOPATH="$HOME/go_projects"
-	export GOBIN="$GOPATH/bin"
-	export GOROOT=$HOME/go
-	export PATH=$PATH:$GOROOT/bin
-
 
 $(LANG_DIR)-clean-dev-env:
 	@echo "Cleaning up..."

--- a/makefile/.konveyor/go/tests.mk
+++ b/makefile/.konveyor/go/tests.mk
@@ -1,0 +1,12 @@
+LOCAL_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+LOCAL_LANG_DIR = $(notdir $(patsubst %/,%,$(dir $(LOCAL_PATH))))
+
+$(LOCAL_LANG_DIR)-tests:
+	$(MAKE) pre-commit
+
+pre-commit: setup-pre-commit
+	. ${PYTHON_VENV}/bin/activate && pre-commit
+
+go-version: setup-pre-commit $(LANG_DIR)-dev-env
+	. ${PYTHON_VENV}/bin/activate && \
+	go version

--- a/makefile/scripts/install_dev_tools
+++ b/makefile/scripts/install_dev_tools
@@ -316,12 +316,10 @@ fi
 
 if should_cli_be_installed "go" "${cli_tools_arr[@]}" && \
     ! [ -x "$(command -v "${VENV}/bin/go")" ]; then
-    GO_INSTALL_LINK="${GO_INSTALL_LINK_NO_ARCH}.darwin-amd64.tar.gz"
+    KERNEL_NAME="$(uname -s | awk '{print tolower($0)}')" # e.g. Linux / Darwin
+    GO_INSTALL_LINK="${GO_INSTALL_LINK_NO_ARCH}.${KERNEL_NAME}-amd64.tar.gz"
     download_file_from_url "${GO_INSTALL_LINK}" "${DWN_DIR}"
     GO_CLIENT_PATH="${DWN_DIR}"/$(basename "${GO_INSTALL_LINK}")
-    extract_file_to_dir "${GO_CLIENT_PATH}" "${VENV}/bin/" "go/bin/go"
-    mv "${VENV}/bin/go/bin/go" "${VENV}/bin/go.bin"
-    rmdir "${VENV}/bin/go/bin"
-    rmdir "${VENV}/bin/go"
-    mv "${VENV}/bin/go.bin" "${VENV}/bin/go"
+    tar -xvf "${GO_CLIENT_PATH}" -C "${VENV}"
+    ln -s "../go/bin/go" "${VENV}/bin/go"
 fi


### PR DESCRIPTION
Change to the install script as go requires all uncompressed
files. Adds the pre-commit and go-version targets.

In this installation methods go does not require to export
GOROOT and relevant env variables as binary is within
extracted dir.