### PR TITLE
Add go specific golangci-lint target to the pre-commit

### DIFF
--- a/makefile/.konveyor/go/tests.mk
+++ b/makefile/.konveyor/go/tests.mk
@@ -7,6 +7,9 @@ $(LOCAL_LANG_DIR)-tests:
 pre-commit: setup-pre-commit
 	. ${PYTHON_VENV}/bin/activate && pre-commit
 
+golangci-lint: setup-pre-commit
+	. ${PYTHON_VENV}/bin/activate && pre-commit run golangci-lint
+
 go-version: setup-pre-commit $(LANG_DIR)-dev-env
 	. ${PYTHON_VENV}/bin/activate && \
 	go version


### PR DESCRIPTION
This is new golangci-lint target added to the pre-commit part
of the Makefile for the go lang.